### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.vscode
+Dockerfile
+example.webp
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.16.2
+
+WORKDIR /retrobot
+
+RUN apk add --no-cache nodejs npm git
+RUN npm install --global yarn cross-env forever
+
+COPY . .
+
+RUN yarn install
+RUN yarn cache clean
+
+ENV FOREVER_ROOT="./forever"
+
+CMD ["forever", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN npm install --global yarn cross-env forever
 
 COPY . .
 
-RUN yarn install
-RUN yarn cache clean
+RUN yarn install && yarn cache clean
 
-ENV FOREVER_ROOT="./forever"
-
-CMD ["forever", "src/index.js"]
+CMD ["yarn", "start"]


### PR DESCRIPTION
Mounting a volume at `/retrobot/data` will allow for game persistence in case of restarts.

2GB of RAM is recommended, but I was able to get GBA Pokemon FireRed to run somewhat reliably on 1GB. I haven't seen how it performs with multiple games yet, if that makes much difference.

It's best not to store secrets in a Docker container, so I added `.env` to the `.dockerignore`. It's recommended the `DISCORD_TOKEN` environment variable be provided to the container at runtime instead.