### PR TITLE
Bot indicates typing when emulating

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,9 @@ const main = async () => {
                     }
 
                     if (playerInputs.length > 0) {
+
+                        message.channel.sendTyping();
+
                         const info = JSON.parse(fs.readFileSync(path.resolve('data', id, 'info.json')).toString());
 
                         let game = fs.readFileSync(path.resolve('data', id, info.game))


### PR DESCRIPTION
When emulation starts the bot will show typing. Intended to help users be patient during longer scenes and encoding intervals.