### PR TITLE
Fix SNES buttons returning 'undefined' in messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,6 +401,10 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
 const joyToWord = (input: InputState) => {
     if (input.A) return 'A';
     if (input.B) return 'B';
+    if (input.X) return 'X';
+    if (input.Y) return 'Y';
+    if (input.L) return 'L';
+    if (input.R) return 'R';
     if (input.UP) return 'Up';
     if (input.DOWN) return 'Down';
     if (input.LEFT) return 'Left';


### PR DESCRIPTION
SNES buttons were missing from `joyToWord`.

![Screenshot_20220918_004132](https://user-images.githubusercontent.com/410905/190887577-bd5d0227-53bc-41d6-956a-7e9b730d0df4.png)
