### PR TITLE
Removed .env from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 .vscode
 Dockerfile
 example.webp
-.env


### PR DESCRIPTION
Otherwise the discord token wouldn't be available inside the docker image.