### PR TITLE
Add node-gyp dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16.2
 
 WORKDIR /retrobot
 
-RUN apk add --no-cache nodejs npm git
+RUN apk add --no-cache nodejs npm git python3 xz-dev make g++
 RUN npm install --global yarn cross-env forever
 
 COPY . .


### PR DESCRIPTION
With the addition of the zip support, node-gyp support is now mandatory, and the image fails to build without these