### PR TITLE
Added "2" option for 2x input presses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,7 +385,7 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
 
     const multiply2 = new ButtonBuilder()
         .setCustomId(id + '-' + '2' + '-' + multiplier)
-        .setEmoji('3️2️⃣')
+        .setEmoji('2️⃣')
         .setDisabled(!enabled)
         .setStyle(highlight == '2' ? ButtonStyle.Success : ButtonStyle.Secondary);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,12 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
         .setDisabled(!enabled)
         .setStyle(highlight == 'start' ? ButtonStyle.Success : ButtonStyle.Secondary);
 
+    const multiply2 = new ButtonBuilder()
+        .setCustomId(id + '-' + '2' + '-' + multiplier)
+        .setEmoji('3️2️⃣')
+        .setDisabled(!enabled)
+        .setStyle(highlight == '2' ? ButtonStyle.Success : ButtonStyle.Secondary);
+
     const multiply3 = new ButtonBuilder()
         .setCustomId(id + '-' + '3' + '-' + multiplier)
         .setEmoji('3️⃣')
@@ -414,7 +420,7 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
                     ),
                 new ActionRowBuilder()
                     .addComponents(
-                        multiply3, multiply5, multiply10
+                        multiply2, multiply3, multiply5, multiply10
                     )
             ] as any[];
 
@@ -434,7 +440,7 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
                     ),
                 new ActionRowBuilder()
                     .addComponents(
-                        multiply3, multiply5, multiply10
+                        multiply2, multiply3, multiply5, multiply10
                     )
             ] as any[];
 
@@ -450,7 +456,7 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
                     ),
                 new ActionRowBuilder()
                     .addComponents(
-                        multiply3, multiply5, multiply10
+                        multiply2, multiply3, multiply5, multiply10
                     )
             ] as any[];
 
@@ -470,7 +476,7 @@ const buttons = (coreType: CoreType, id: string, multiplier: number = 1, enabled
                     ),
                 new ActionRowBuilder()
                     .addComponents(
-                        multiply3, multiply5, multiply10
+                        multiply2, multiply3, multiply5, multiply10
                     )
             ] as any[];
     }


### PR DESCRIPTION
For games like Pokemon, where a single press of a button will change facing rather than just stepping, having a 2x option is helpful to tun and move one step, which saves multiple presses and thus multiple gif generations. Tested working on my Discord server.